### PR TITLE
Relax port annotation requirement, fix to prevent 0 value port getting through.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION   := 0.1.5
 TYPE      := alpha
 COMMIT    := $(shell git rev-parse HEAD)
 IMAGE     := quay.io/samsung_cnct/lbex
+TAG       ?= latest
 godep=GOPATH=$(shell godep path):${GOPATH}
 
 build:
@@ -47,14 +48,14 @@ container:
 	-osarch="linux/amd64" \
 	-output "build/{{.OS}}_{{.Arch}}/$(NAME)" \
 	./...
-	docker build --rm --pull --tag $(IMAGE):latest .
+	docker build --rm --pull --tag $(IMAGE):$(TAG) .
 
 tag: container
-	docker tag $(IMAGE):latest $(IMAGE):$(COMMIT)
+	docker tag $(IMAGE):$(TAG) $(IMAGE):$(COMMIT)
 
 push: tag
 	docker push $(IMAGE):$(COMMIT)
-	docker push $(IMAGE):latest
+	docker push $(IMAGE):$(TAG)
 
 release: dist push
 	@latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := lbex
-VERSION   := 0.1.5
+VERSION   := 0.1.6
 TYPE      := alpha
 COMMIT    := $(shell git rev-parse HEAD)
 IMAGE     := quay.io/samsung_cnct/lbex

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The format of the environment variable for flag `--example-flag` is LBEX_EXAMPLE
 
 Not every flag is exposed via an environment variable due to flag list being aggregated from 3rd party Go packages, in particular the packages used for logging.  Every flag and corresponding environment variable support is listed in the table below:
  Flag | Enviroment Variable
-:-------|:----------------:
+--- | ---
 --alsologtostderr | None
 --anti-affinity | Supported
 --health-check | Supported

--- a/annotations/service_annotation.go
+++ b/annotations/service_annotation.go
@@ -178,10 +178,8 @@ func GetOptionalIntAnnotation(name string, obj interface{}) (int, bool) {
 }
 
 // IsValid returns true if the given Service object specifies 'lbex' as the
-// value to the loadbalancer.class annotation and has a valid port specified through
-// the loadbalancer.lbex/port annnotation
+// value to the loadbalancer.class annotation.
 func IsValid(obj interface{}) bool {
 	class, _ := GetOptionalStringAnnotation(LBEXClassKey, obj)
-	port, _ := GetOptionalIntAnnotation(LBEXPortKey, obj)
-	return (class == LBEXClassKeyValue) && (port != 0)
+	return class == LBEXClassKeyValue
 }

--- a/config.go
+++ b/config.go
@@ -18,11 +18,15 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/golang/glog"
 	flag "github.com/spf13/pflag"
 )
 
 type config struct {
+	flagSet         *flag.FlagSet
 	kubeconfig      *string
 	proxy           *string
 	serviceName     *string
@@ -55,4 +59,73 @@ func (cfg *config) String() string {
 		"anti-affinity: %t, health-check: %t, health-check-port: %d, require-port: %t",
 		*cfg.kubeconfig, *cfg.proxy, *cfg.serviceName, *cfg.servicePool, *cfg.strictAffinity,
 		*cfg.antiAffinity, *cfg.healthCheck, *cfg.healthCheckPort, *cfg.requirePort)
+}
+
+var envSupport = map[string]bool{
+	"kubeconfig":      true,
+	"proxy":           true,
+	"service-name":    true,
+	"service-pool":    true,
+	"strict-affinity": true,
+	"anti-affinity":   true,
+	"version":         false,
+	"health-check":    true,
+	"health-port":     true,
+	"require-port":    true,
+}
+
+func variableName(name string) string {
+	return "LBEX_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
+}
+
+// Just like Flags.Parse() except we try to get recognized values for the valid
+// set of flags from environment variables.  We choose to use the environment
+// value if 1) the value hasen't already been set as command line flags and the
+// flas is a member of the supported set (see map defined above).
+func (cfg *config) envParse() error {
+	var err error
+
+	alreadySet := make(map[string]bool)
+	cfg.flagSet.Visit(func(f *flag.Flag) {
+		if envSupport[f.Name] {
+			alreadySet[variableName(f.Name)] = true
+		}
+	})
+
+	usedEnvKey := make(map[string]bool)
+	cfg.flagSet.VisitAll(func(f *flag.Flag) {
+		if envSupport[f.Name] {
+			key := variableName(f.Name)
+			glog.V(4).Infof("supported key: %v", key)
+			if !alreadySet[key] {
+				val := os.Getenv(key)
+				if val != "" {
+					usedEnvKey[key] = true
+					if serr := cfg.flagSet.Set(f.Name, val); serr != nil {
+						err = fmt.Errorf("invalid value %q for %s: %v", val, key, serr)
+					}
+					glog.V(3).Infof("recognized and used environment variable %s=%s", key, val)
+				}
+			}
+		}
+	})
+
+	for _, env := range os.Environ() {
+		kv := strings.SplitN(env, "=", 2)
+		if len(kv) != 2 {
+			glog.Warningf("found invalid env %s", env)
+		}
+		if usedEnvKey[kv[0]] {
+			continue
+		}
+		if alreadySet[kv[0]] {
+			glog.V(3).Infof("recognized environment variable %s, but unused: superseeded by command line flag ", kv[0])
+			continue
+		}
+		if strings.HasPrefix(env, "LBEX_") {
+			glog.Warningf("unrecognized environment variable %s", env)
+		}
+	}
+
+	return err
 }

--- a/config.go
+++ b/config.go
@@ -96,7 +96,6 @@ func (cfg *config) envParse() error {
 	cfg.flagSet.VisitAll(func(f *flag.Flag) {
 		if envSupport[f.Name] {
 			key := variableName(f.Name)
-			glog.V(4).Infof("supported key: %v", key)
 			if !alreadySet[key] {
 				val := os.Getenv(key)
 				if val != "" {

--- a/controller.go
+++ b/controller.go
@@ -480,7 +480,7 @@ func (lbex *lbExController) baseCheck(obj interface{}) bool {
 		port, err := annotations.GetIntAnnotation(annotations.LBEXPortKey, obj)
 		if err != nil {
 			if annotations.IsMissingAnnotations(err) {
-				glog.V(2).Infof("missing required annotation: %s", annotations.LBEXPortKey)
+				glog.Warningf("missing required annotation: %s", annotations.LBEXPortKey)
 			} else {
 				glog.V(2).Infof("unexpected error processing annotation annotation, err: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -92,6 +92,9 @@ func main() {
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
 
+	lbexCfg.flagSet = flag.CommandLine
+	lbexCfg.envParse()
+
 	// check for version flag, if present print veriosn and exit
 	if *lbexCfg.version {
 		displayVersion()

--- a/nginx/configurator.go
+++ b/nginx/configurator.go
@@ -343,10 +343,14 @@ func (cfgtor *Configurator) generateStreamNginxConfig(svc *ServiceSpec) (svcConf
 				upstream.LeastTimeMethod = ValidateMethod(val)
 			}
 
-			lbexPort, _ := annotations.GetOptionalIntAnnotation(annotations.LBEXPortKey, svc.Service)
+			listenPort, ok := annotations.GetOptionalIntAnnotation(annotations.LBEXPortKey, svc.Service)
+			if !ok {
+				// value was not retrieved from the indicated annotation, so use the service port.
+				listenPort = target.ServicePort
+			}
 			server := StreamServer{
 				Listen: StreamListen{
-					Port: strconv.Itoa(lbexPort),
+					Port: strconv.Itoa(listenPort),
 					UDP:  strings.EqualFold(target.Protocol, udpProto),
 				},
 				ProxyProtocol:    false,

--- a/nginx/configurator.go
+++ b/nginx/configurator.go
@@ -343,8 +343,8 @@ func (cfgtor *Configurator) generateStreamNginxConfig(svc *ServiceSpec) (svcConf
 				upstream.LeastTimeMethod = ValidateMethod(val)
 			}
 
-			listenPort, ok := annotations.GetOptionalIntAnnotation(annotations.LBEXPortKey, svc.Service)
-			if !ok {
+			listenPort, err := annotations.GetIntAnnotation(annotations.LBEXPortKey, svc.Service)
+			if err != nil || listenPort == 0 {
 				// value was not retrieved from the indicated annotation, so use the service port.
 				listenPort = target.ServicePort
 			}

--- a/service.go
+++ b/service.go
@@ -93,7 +93,7 @@ func (s serviceByName) Less(i, j int) bool {
 // ValidateServiceObject returns true iff:
 // - the object is of a valid v1 API Service object
 // - is a service type we provide load balancing for
-// - has a valid annotation indicating
+// - has a valid annotation indicating the lbex class
 // returns false otherwise
 func ValidateServiceObject(obj interface{}) bool {
 	err := ValidateServiceObjectType(obj)


### PR DESCRIPTION
Also includes a commit to the makefile so that we can override the tag and push to the repository with a tag other than 'latest' for in cluster testing that doesn't affect 'latest'